### PR TITLE
Alternate native preload

### DIFF
--- a/ClientKit/ClientKit.cs
+++ b/ClientKit/ClientKit.cs
@@ -90,22 +90,30 @@ namespace OSVR
             static public void PreloadNativeLibraries()
             {
 #if !MANAGED_OSVR_INTERNAL_PINVOKE
-                String path;
+
                 // This line based on http://stackoverflow.com/a/864497/265522
                 var assembly = System.Uri.UnescapeDataString((new System.Uri(System.Reflection.Assembly.GetExecutingAssembly().CodeBase)).AbsolutePath);
                 var assemblyPath = Path.GetDirectoryName(assembly);
                 System.Diagnostics.Debug.WriteLine("[OSVR] ClientKit assembly directory: " + assemblyPath);
+                LibraryPathAttempter attempt;
                 if (IntPtr.Size == 8)
                 {
-                    path = new PathChecker(assemblyPath).Check("x86_64").Check("x64").Check("64").Result;
+                    attempt = new LibraryPathAttempter(assemblyPath).Attempt("x86_64").Attempt("x64").Attempt("64");
                 }
                 else
                 {
-                    path = new PathChecker(assemblyPath).Check("x86").Check("32").Result;
+                    attempt = new LibraryPathAttempter(assemblyPath).Attempt("x86").Attempt("32");
                 }
-                if (path.Length > 0)
+                if (attempt.Success)
                 {
-                    System.Diagnostics.Debug.WriteLine("[OSVR] Found ClientKit native libraries in directory: " + path);
+                    if (attempt.Dir.Length > 0)
+                    {
+                        System.Diagnostics.Debug.WriteLine("[OSVR] Loaded ClientKit native libraries from directory: " + attempt.Dir);
+                    }
+                    else
+                    {
+                        System.Diagnostics.Debug.WriteLine("[OSVR] Loaded ClientKit native libraries from default search path.");
+                    }
                 }
                 else
                 {
@@ -116,50 +124,112 @@ namespace OSVR
 
 #if !MANAGED_OSVR_INTERNAL_PINVOKE
 
-            private class PathChecker
+            private class LibraryPathAttempter
             {
                 [DllImport("kernel32", SetLastError = true, CharSet = CharSet.Ansi)]
                 private static extern IntPtr LoadLibrary([MarshalAs(UnmanagedType.LPStr)]string lpFileName);
 
-                public PathChecker(string path)
+                /// <summary>
+                /// Constructor - includes an "attempt" using the
+                /// default search path and the assembly path
+                /// </summary>
+                /// <param name="dir">Directory containing this assembly.</param>
+                public LibraryPathAttempter(string dir)
                 {
-                    AssemblyPath = path;
-                    CheckDir("");
-                    CheckDir(path);
+                    AssemblyDir = dir;
+                    AttemptDirectory("");
+                    AttemptDirectory(dir);
                 }
 
-                public PathChecker Check(string suffix)
+                /// <summary>
+                /// Chained method call to provide a subdirectory of the
+                /// assembly directory to try to load the native
+                /// libraries from
+                /// </summary>
+                /// <param name="pathSuffix">
+                /// Name of subdirectory of the assembly directory.
+                /// </param>
+                /// <returns>
+                /// This object for additional chained calls
+                /// </returns>
+                public LibraryPathAttempter Attempt(string pathSuffix)
                 {
                     if (!KeepTrying)
                     {
                         return this;
                     }
-                    CheckDir(Path.Combine(AssemblyPath, suffix));
+                    AttemptDirectory(Path.Combine(AssemblyDir, pathSuffix));
                     return this;
                 }
 
-                public string Result
+                /// <summary>
+                /// The directory that we successfully loaded native
+                /// libraries from. An empty string may mean we failed
+                /// to load the libraries or we found them on the
+                /// default search path, see Success to disambiguate.
+                /// </summary>
+                public string Dir
                 {
                     get
                     {
-                        return DllPath;
+                        return DllDir;
                     }
                 }
 
-                private void CheckDir(string dir)
+                /// <summary>
+                /// Indicates whether or not we were able to pre-load the native libraries.
+                /// </summary>
+                public bool Success
+                {
+                    get
+                    {
+                        return LoadedSuccess;
+                    }
+                }
+
+                /// <summary>
+                /// Attempts to load native libraries from the given
+                /// directory. If successful, sets Result to dir.
+                /// </summary>
+                /// <param name="dir">
+                /// Base directory to try loading from - empty string
+                /// implies "default search path"
+                /// </param>
+                private void AttemptDirectory(string dir)
                 {
                     if (!KeepTrying)
                     {
                         return;
                     }
-                    if (CheckDir(dir, "", ".dll") || CheckDir(dir, "lib", ".so"))
+                    if (AttemptDirectory(dir, "", ".dll") || AttemptDirectory(dir, "lib", ".so"))
                     {
-                        DllPath = dir;
+                        DllDir = dir;
+                        LoadedSuccess = true;
                         KeepTrying = false;
                     }
                 }
 
-                private bool CheckDir(string dir, string prefix, string suffix)
+                /// <summary>
+                /// Attempts to load native libraries from the given
+                /// directory with the provided formula (prefix and
+                /// suffix), effectively dir + prefix + libname + suffix
+                /// </summary>
+                /// <param name="dir">
+                /// Base directory to try loading from - empty string
+                /// implies "default search path"
+                /// </param>
+                /// <param name="prefix">
+                /// The string to prepend to the library's canonical
+                /// name to get the filename
+                /// </param>
+                /// <param name="suffix">
+                /// The string to append to the end of the library's
+                /// canonical name to get the filename - essentially the extension.
+                /// </param>
+                /// <returns>
+                /// true if all libraries were successfully loaded.
+                /// </returns>
+                private bool AttemptDirectory(string dir, string prefix, string suffix)
                 {
                     if (!KeepTrying)
                     {
@@ -174,7 +244,7 @@ namespace OSVR
                     {
                         foreach (var lib in NativeLibs)
                         {
-                            var libName = produceLibPath(dir, prefix, suffix, lib);
+                            var libName = ProduceLibPath(dir, prefix, suffix, lib);
                             System.Diagnostics.Debug.WriteLine(String.Format("[OSVR] Trying to LoadLibrary: {0}", libName));
                             var result = LoadLibrary(libName);
                             if (result == IntPtr.Zero)
@@ -194,7 +264,28 @@ namespace OSVR
                     return success;
                 }
 
-                private String produceLibPath(string dir, string prefix, string suffix, string lib)
+                /// <summary>
+                /// Combine a base directory, prefix, suffix, and
+                /// library canonical name into a path to pass to
+                /// LoadLibrary, specially handling the case of empty
+                /// base directory for default search path (no path
+                /// delimiter or extension/suffix)
+                /// </summary>
+                /// <param name="dir">
+                /// Base directory to try loading from - empty string
+                /// implies "default search path"
+                /// </param>
+                /// <param name="prefix">
+                /// The string to prepend to the library's canonical
+                /// name to get the filename
+                /// </param>
+                /// <param name="suffix">
+                /// The string to append to the end of the library's
+                /// canonical name to get the filename - essentially the extension.
+                /// </param>
+                /// <param name="lib">The library's canonical name</param>
+                /// <returns>A library name or path to pass to LoadLibrary</returns>
+                private static String ProduceLibPath(string dir, string prefix, string suffix, string lib)
                 {
                     return dir.Length > 0 ? Path.Combine(dir, prefix + lib + suffix) : prefix + lib;
                 }
@@ -205,8 +296,10 @@ namespace OSVR
                 /// library may only depend on libraries earlier in the list.
                 /// </summary>
                 private String[] NativeLibs = { "osvrUtil", "osvrCommon", "osvrClient", "osvrClientKit" };
-                private string AssemblyPath;
-                private string DllPath;
+
+                private string AssemblyDir;
+                private string DllDir;
+                private bool LoadedSuccess = false;
                 private bool KeepTrying = true;
             }
 

--- a/ExampleClients/AnalogCallback/AnalogCallback.cs
+++ b/ExampleClients/AnalogCallback/AnalogCallback.cs
@@ -30,6 +30,7 @@ namespace AnalogCallback
 
         static void Main(string[] args)
         {
+            ClientContext.PreloadNativeLibraries();
 			using (OSVR.ClientKit.ClientContext context = new OSVR.ClientKit.ClientContext("com.osvr.exampleclients.managed.AnalogCallback"))
             {
                 // This is just one of the paths: specifically, the Hydra's left

--- a/ExampleClients/ButtonCallback/ButtonCallback.cs
+++ b/ExampleClients/ButtonCallback/ButtonCallback.cs
@@ -29,6 +29,7 @@ namespace ButtonCallback
         }
         static void Main(string[] args)
         {
+            ClientContext.PreloadNativeLibraries();
 			using (OSVR.ClientKit.ClientContext context = new OSVR.ClientKit.ClientContext("com.osvr.exampleclients.managed.ButtonCallback"))
             {
                 // This is just one of the paths: specifically, the Hydra's left

--- a/ExampleClients/ButtonState/ButtonState.cs
+++ b/ExampleClients/ButtonState/ButtonState.cs
@@ -25,6 +25,7 @@ namespace ButtonState
     {
         public static void Main(string[] args)
         {
+            ClientContext.PreloadNativeLibraries();
 			using (ClientContext context = new ClientContext("com.osvr.exampleclients.managed.TrackerCallback"))
             {
 #if NET20

--- a/ExampleClients/DisplayParameter/DisplayParameter.cs
+++ b/ExampleClients/DisplayParameter/DisplayParameter.cs
@@ -25,6 +25,7 @@ namespace DisplayParameter
     {
         static void Main(string[] args)
         {
+            ClientContext.PreloadNativeLibraries();
 			using (OSVR.ClientKit.ClientContext context = new OSVR.ClientKit.ClientContext("com.osvr.exampleclients.managed.DisplayParameter"))
             {
                 string displayDescription = context.getStringParameter("/display");

--- a/ExampleClients/InterfaceAdapter/InterfaceAdapter.cs
+++ b/ExampleClients/InterfaceAdapter/InterfaceAdapter.cs
@@ -73,6 +73,7 @@ namespace InterfaceAdapter
 
         public static void Main(string[] args)
         {
+            ClientContext.PreloadNativeLibraries();
 			using (ClientContext context = new ClientContext("com.osvr.exampleclients.managed.TrackerCallback"))
             {
                 // We're creating an adapter from the OSVR native PositionInterface to a custom interface where the

--- a/ExampleClients/TrackerCallback/TrackerCallback.cs
+++ b/ExampleClients/TrackerCallback/TrackerCallback.cs
@@ -63,6 +63,7 @@ namespace TrackerCallback
     {
         public static void Main(string[] args)
         {
+            ClientContext.PreloadNativeLibraries();
 			using (ClientContext context = new ClientContext("com.osvr.exampleclients.managed.TrackerCallback"))
             {
                 // This is just one of the paths. You can also use:


### PR DESCRIPTION
Turns out that the PATH manipulation in the Unity code doesn't work well (at all) with the `SetDllDirectory` static constructor I had added here. Thus, as suggested in https://github.com/OSVR/OSVR-Unity/issues/19#issuecomment-90218483, I've switched to doing `LoadLibrary` calls of the DLLs in dependency order. Further, I've moved that out of a static constructor and just into a plain static method, for optional calling if you want that added help in ensuring you can find the native libs.

I can confirm that running the examples on a 64-bit machine (in 64-bit mode) works, and the assembly works when used with the Unity integration.

Caveats to my testing or design: I don't know if there's a way to only call the `LoadLibrary` code if it's required (in a static constructor, so it would be automatic in a more cautious way), or if Mono or other runtimes do a mapping so that a pinvoke of `LoadLibrary` makes something happen on non-Windows platforms thus making my inclusion of `lib*.so` code worthwhile. Also, at the moment we're just basically "leaking" the library handles - just a one-time thing, though, automatically cleaned up at process exit, (if the static method is called again, additional loadlibrary calls just increase a per-process ref count, so no way it will leak more than 4 library handles), and I wouldn't really expect to be able to change the native DLLs out from under an app while it's running anyway.
