### PR TITLE
Centralized DllImport library names into one static class, OSVRLibNames.

### DIFF
--- a/ClientKit/ClientKit.cs
+++ b/ClientKit/ClientKit.cs
@@ -52,19 +52,10 @@ namespace OSVR
         /// </summary>
         public class ServerAutoStarter : IDisposable
         {
-#if MANAGED_OSVR_INTERNAL_PINVOKE
-            // On iOS and Xbox 360, plugins are statically linked into
-            // the executable, so we have to use __Internal as the
-            // library name.
-            private const string OSVRCoreDll = "__Internal";
-#else
-            private const string OSVRCoreDll = "osvrClientKit";
-#endif
-
-            [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             internal extern static void osvrClientAttemptServerAutoStart();
 
-            [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             internal extern static void osvrClientReleaseAutoStartedServer();
 
             public ServerAutoStarter()
@@ -105,41 +96,31 @@ namespace OSVR
         {
             #region ClientKit C functions
 
-            // Should be defined if used with Unity and UNITY_IOS or UNITY_XBOX360 are defined
-#if MANAGED_OSVR_INTERNAL_PINVOKE
-            // On iOS and Xbox 360, plugins are statically linked into
-            // the executable, so we have to use __Internal as the
-            // library name.
-            private const string OSVRCoreDll = "__Internal";
-#else
-            private const string OSVRCoreDll = "osvrClientKit";
-#endif
-
             public static Byte OSVR_RETURN_SUCCESS = 0x0;
             public static Byte OSVR_RETURN_FAILURE = 0x1;
 
-            [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static SafeClientContextHandle osvrClientInit([MarshalAs(UnmanagedType.LPStr)] string applicationIdentifier, [MarshalAs(UnmanagedType.U4)] uint flags);
 
-            [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrClientUpdate(SafeClientContextHandle ctx);
 
-            [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrClientShutdown(IntPtr /*OSVR_ClientContext*/ ctx);
 
-            [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrClientGetStringParameterLength(SafeClientContextHandle ctx, string path, out UIntPtr len);
 
-            [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrClientGetStringParameter(SafeClientContextHandle ctx, string path, StringBuilder buf, UIntPtr len);
 
-            [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             internal extern static Byte osvrClientCheckStatus(SafeClientContextHandle ctx);
 
-            [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             internal extern static Byte osvrClientSetRoomRotationUsingHead(SafeClientContextHandle ctx);
 
-            [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             internal extern static Byte osvrClientClearRoomToWorldTransform(SafeClientContextHandle ctx);
 
             #endregion ClientKit C functions

--- a/ClientKit/ClientKit.csproj
+++ b/ClientKit/ClientKit.csproj
@@ -27,6 +27,7 @@
     <Compile Include="InterfaceAdapter.cs" />
     <Compile Include="InterfaceBase.cs" />
     <Compile Include="JointClientKit.cs" />
+    <Compile Include="OSVRLibNames.cs" />
     <Compile Include="Location2DInterface.cs" />
     <Compile Include="MatrixConventions.cs" />
     <Compile Include="NaviPositionInterface.cs" />

--- a/ClientKit/Display.cs
+++ b/ClientKit/Display.cs
@@ -89,91 +89,82 @@ namespace OSVR.ClientKit
     }
 
     internal static class DisplayConfigNative {
-#if MANAGED_OSVR_INTERNAL_PINVOKE
-            // On iOS and Xbox 360, plugins are statically linked into
-            // the executable, so we have to use __Internal as the
-            // library name.
-            private const string OSVRCoreDll = "__Internal";
-#else
-            private const string OSVRCoreDll = "osvrClientKit";
-#endif
-
-        [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientGetDisplay(SafeClientContextHandle context, out SafeDisplayConfigHandle display);
 
-        [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientFreeDisplay(IntPtr display);
 
-        [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientCheckDisplayStartup(SafeDisplayConfigHandle context);
 
-        [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientGetNumDisplayInputs(SafeDisplayConfigHandle display, out DisplayInputCount numDisplayInputs);
 
-        [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientGetDisplayDimensions(SafeDisplayConfigHandle display,
             DisplayInputCount displayInputIndex, out DisplayDimension width, out DisplayDimension height);
 
-        [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientGetNumViewers(SafeDisplayConfigHandle display, out ViewerCount viewers);
 
-        [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientGetViewerPose(SafeDisplayConfigHandle display,
             ViewerCount viewer, out Pose3 pose);
 
-        [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientGetNumEyesForViewer(SafeDisplayConfigHandle display,
             ViewerCount viewer, out EyeCount eyes);
 
-        [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientGetViewerEyePose(SafeDisplayConfigHandle display,
             ViewerCount viewer, EyeCount eye, out Pose3 pose);
 
-        [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientGetViewerEyeViewMatrixd(SafeDisplayConfigHandle display,
             ViewerCount viewer, EyeCount eye, MatrixConventionsFlags flags, out Matrix44d mat);
 
-        [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientGetViewerEyeViewMatrixf(SafeDisplayConfigHandle display,
             ViewerCount viewer, EyeCount eye, MatrixConventionsFlags flags, out Matrix44f mat);
 
-        [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientGetNumSurfacesForViewerEye(SafeDisplayConfigHandle display,
             ViewerCount viewer, EyeCount eye, out SurfaceCount surfaces);
 
-        [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientGetRelativeViewportForViewerEyeSurface(SafeDisplayConfigHandle display,
             ViewerCount viewer, EyeCount eye, SurfaceCount surface,
             out ViewportDimension left, out ViewportDimension bottom, out ViewportDimension width, out ViewportDimension height);
 
-        [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientGetViewerEyeSurfaceDisplayInputIndex(SafeDisplayConfigHandle display,
             ViewerCount viewer, EyeCount eye, SurfaceCount surface, out DisplayInputCount displayInput);
 
-        [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientGetViewerEyeSurfaceProjectionMatrixd(SafeDisplayConfigHandle display,
             ViewerCount viewer, EyeCount eye, SurfaceCount surface, double near, double far,
             MatrixConventionsFlags flags, out Matrix44d matrix);
 
-        [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientGetViewerEyeSurfaceProjectionMatrixf(SafeDisplayConfigHandle display,
             ViewerCount viewer, EyeCount eye, SurfaceCount surface, float near, float far,
             MatrixConventionsFlags flags, out Matrix44f matrix);
 
-        [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientGetViewerEyeSurfaceProjectionClippingPlanes(SafeDisplayConfigHandle display,
             ViewerCount viewer, EyeCount eye, SurfaceCount surface,
             out double left, out double right, out double bottom, out double top);
 
-        [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientDoesViewerEyeSurfaceWantDistortion(SafeDisplayConfigHandle display,
             ViewerCount viewer, EyeCount eye, SurfaceCount surface, [MarshalAs(UnmanagedType.I1)]out bool distortionRequested);
 
-        [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientGetViewerEyeSurfaceRadialDistortionPriority(SafeDisplayConfigHandle display,
             ViewerCount viewer, EyeCount eye, SurfaceCount surface, out DistortionPriority priority);
 
-        [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientGetViewerEyeSurfaceRadialDistortion(SafeDisplayConfigHandle display,
             ViewerCount viewer, EyeCount eye, SurfaceCount surface, out RadialDistortionParameters distortionParams);
     }

--- a/ClientKit/ImagingInterface.cs
+++ b/ClientKit/ImagingInterface.cs
@@ -33,16 +33,7 @@ namespace OSVR.ClientKit
 
     internal static class ImagingInterfaceNative
     {
-#if UNITY_IPHONE || UNITY_XBOX360
-			// On iOS and Xbox 360, plugins are statically linked into
-			// the executable, so we have to use __Internal as the
-			// library name.
-			const string OSVR_CORE_DLL = "__Internal";
-#else
-        const string OSVR_CORE_DLL = "osvrClientKit";
-#endif
-
-        [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public static extern Byte osvrClientFreeImage(SafeClientContextHandle ctx, IntPtr imageData);
     }
 

--- a/ClientKit/Interface.cs
+++ b/ClientKit/Interface.cs
@@ -82,99 +82,91 @@ namespace OSVR
         {
 
             #region ClientKit C functions
-#if UNITY_IPHONE || UNITY_XBOX360
-			// On iOS and Xbox 360, plugins are statically linked into
-			// the executable, so we have to use __Internal as the
-			// library name.
-			const string OSVR_CORE_DLL = "__Internal";
-#else
-            const string OSVR_CORE_DLL = "osvrClientKit";
-#endif
 
             //typedef struct OSVR_ClientContextObject *OSVR_ClientContext;
             //typedef struct OSVR_ClientInterfaceObject *OSVR_ClientInterface;
             //typedef char OSVR_ReturnCode; (0 == OSVR_RETURN_SUCCESS; 1 == OSVR_RETURN_FAILURE)
 
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrRegisterPositionCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] PositionCallback cb, IntPtr /*void**/ userdata);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrRegisterPoseCallback(SafeClientInterfaceHandle iface, PoseCallback cb, IntPtr /*void**/ userdata);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrRegisterOrientationCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] OrientationCallback cb, IntPtr /*void**/ userdata);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrRegisterButtonCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] ButtonCallback cb, IntPtr /*void**/ userdata);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrRegisterAnalogCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] AnalogCallback cb, IntPtr /*void**/ userdata);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrRegisterLocation2DCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] Location2DCallback cb, IntPtr /*void**/ userdata);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrRegisterDirectionCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] DirectionCallback cb, IntPtr /*void**/ userdata);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrRegisterEyeTracker2DCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] EyeTracker2DCallback cb, IntPtr /*void**/ userdata);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrRegisterEyeTracker3DCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] EyeTracker3DCallback cb, IntPtr /*void**/ userdata);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrRegisterEyeTrackerBlinkCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] EyeTrackerBlinkCallback cb, IntPtr /*void**/ userdata);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrRegisterImagingCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] ImagingCallback cb, IntPtr /*void**/ userdata);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrRegisterNaviVelocityCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] NaviVelocityCallback cb, IntPtr /*void*/ userdata);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrRegisterNaviPositionCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] NaviPositionCallback cb, IntPtr /*void*/ userdata);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrClientGetInterface(SafeClientContextHandle ctx, string path, ref SafeClientInterfaceHandle iface);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrGetPoseState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref Pose3 state);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrGetPositionState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref Vec3 state);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrGetOrientationState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref Quaternion state);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrGetButtonState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref Byte state);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrGetAnalogState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref Double state);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrGetLocation2DState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref Vec2 state);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrGetDirectionState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref Vec3 state);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrGetEyeTracker2DState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref Vec2 state);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrGetEyeTracker3DState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref EyeTracker3DState state);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrGetEyeTrackerBlinkState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, [MarshalAs(UnmanagedType.I1)]ref bool state);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrGetNaviVelocityState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref Vec2 state);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrGetNaviPositionState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref Vec2 state);
 
-            [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrClientFreeInterface(IntPtr iface);
 
             #endregion

--- a/ClientKit/JointClientKit.cs
+++ b/ClientKit/JointClientKit.cs
@@ -39,45 +39,36 @@ namespace OSVR.ClientKit
 
     internal static class JointClientKitNative
     {
-#if MANAGED_OSVR_INTERNAL_PINVOKE
-            // On iOS and Xbox 360, plugins are statically linked into
-            // the executable, so we have to use __Internal as the
-            // library name.
-            private const string OSVRCoreDll = "__Internal";
-#else
-        private const string JointClientKitDll = "osvrJointClientKit";
-#endif
-
-        [DllImport(JointClientKitDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static IntPtr /*SafeJointClientOptionsHandle*/ osvrJointClientCreateOptions();
 
-        [DllImport(JointClientKitDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrJointClientOptionsAutoloadPlugins(IntPtr /*SafeJointClientOptionsHandle*/ options);
 
-        [DllImport(JointClientKitDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrJointClientOptionsLoadPlugin(IntPtr /*SafeJointClientOptionsHandle*/ options,
             string pluginName);
 
-        [DllImport(JointClientKitDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrJointClientOptionsInstantiateDriver(IntPtr /*SafeJointClientOptionsHandle*/ options,
             string pluginName, string driverName, string parameters);
 
-        [DllImport(JointClientKitDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrJointClientOptionsAddAlias(IntPtr /*SafeJointClientOptionsHandle*/ options,
             string path, string source);
 
-        [DllImport(JointClientKitDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrJointClientOptionsAddAliases(IntPtr /*SafeJointClientOptionsHandle*/ options,
             string aliases);
 
-        [DllImport(JointClientKitDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrJointClientOptionsAddString(IntPtr /*SafeJointClientOptionsHandle*/ options,
             string path, string s);
 
-        [DllImport(JointClientKitDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrJointClientOptionsTriggerHardwareDetect(IntPtr /*SafeJointClientOptionsHandle*/ options);
 
-        [DllImport(JointClientKitDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.ClientKit, CallingConvention = CallingConvention.Cdecl)]
         public extern static SafeClientContextHandle osvrJointClientInit(
             string applicationIdentifier, IntPtr /*SafeJointClientOptionsHandle*/ options);
     }

--- a/ClientKit/MatrixConventions.cs
+++ b/ClientKit/MatrixConventions.cs
@@ -145,19 +145,10 @@ namespace OSVR.ClientKit
 
     internal static class MatrixConventionsNative
     {
-        #if MANAGED_OSVR_INTERNAL_PINVOKE
-        // On iOS and Xbox 360, plugins are statically linked into
-        // the executable, so we have to use __Internal as the
-        // library name.
-        private const string OSVRUtilDll = "__Internal";
-#else
-        private const string OSVRUtilDll = "osvrUtil";
-#endif
-
-        [DllImport(OSVRUtilDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.Util, CallingConvention = CallingConvention.Cdecl)]
         public static extern Byte osvrPose3ToMatrixd(ref Pose3 pose, MatrixConventionsFlags flags, out Matrix44d mat);
 
-        [DllImport(OSVRUtilDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(OSVRLibNames.Util, CallingConvention = CallingConvention.Cdecl)]
         public static extern Byte osvrPose3ToMatrixf(ref Pose3 pose, MatrixConventionsFlags flags, out Matrix44f mat);
     }
 

--- a/ClientKit/OSVRLibNames.cs
+++ b/ClientKit/OSVRLibNames.cs
@@ -1,0 +1,35 @@
+﻿/// Managed-OSVR binding
+///
+/// <copyright>
+/// Copyright 2014, 2015 Sensics, Inc. and contributors
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+/// </copyright>
+
+
+namespace OSVR
+{
+    internal static class OSVRLibNames
+    {
+        // Should be defined if used with Unity and UNITY_IOS or UNITY_XBOX360 are defined
+#if MANAGED_OSVR_INTERNAL_PINVOKE
+        public const string ClientKit = "__Internal";
+        public const string Util = "__Internal";
+        public const string RenderManager = "__Internal";
+#else
+        public const string ClientKit = "osvrClientKit";
+        public const string Util = "osvrUtil";
+        public const string RenderManager = "osvrRenderManager";
+#endif
+    }
+}


### PR DESCRIPTION
Instead of repeating the `MANAGED_OSVR_INTERNAL_PINVOKE` switch and duplicating the OSVR library names everywhere P/Invoke methods are defined, this centralizes those names into one internal static class, `OSVRLibNames`.
