### PR TITLE
Windows 10 Universal plateform build fixes

### DIFF
--- a/ClientKit/BuildConstants.cs
+++ b/ClientKit/BuildConstants.cs
@@ -28,6 +28,8 @@ namespace OSVR.ClientKit
         public const string FrameworkDescription = ".NET 2.0";
 #elif NET45
         public const string FrameworkDescription = ".NET 4.5";
+#elif WINDOWS_UWP
+        public const string FrameworkDescription = ".Net 4.6";
 #else
 #error "Building for some unrecognized .NET version!"
 #endif

--- a/ClientKit/ClientKit.cs
+++ b/ClientKit/ClientKit.cs
@@ -69,11 +69,16 @@ namespace OSVR
             private const string OSVRCoreDll = "osvrClientKit";
 #endif
 
+#if WINDOWS_UWP
+            internal static void osvrClientAttemptServerAutoStart() { }
+            internal static void osvrClientReleaseAutoStartedServer() { }
+#else
             [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
             internal extern static void osvrClientAttemptServerAutoStart();
 
             [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
             internal extern static void osvrClientReleaseAutoStartedServer();
+#endif
 
             public ServerAutoStarter()
             {
@@ -111,7 +116,7 @@ namespace OSVR
         /// @ingroup ClientKitCPP
         public class ClientContext : IDisposable
         {
-            #region ClientKit C functions
+#region ClientKit C functions
 
             // Should be defined if used with Unity and UNITY_IOS or UNITY_XBOX360 are defined
 #if MANAGED_OSVR_INTERNAL_PINVOKE
@@ -126,6 +131,26 @@ namespace OSVR
             public static Byte OSVR_RETURN_SUCCESS = 0x0;
             public static Byte OSVR_RETURN_FAILURE = 0x1;
 
+#if WINDOWS_UWP
+            public static SafeClientContextHandle osvrClientInit([MarshalAs(UnmanagedType.LPStr)] string applicationIdentifier, [MarshalAs(UnmanagedType.U4)] uint flags)
+            {
+                return null;
+            }
+
+            public static Byte osvrClientUpdate(SafeClientContextHandle ctx) { return 0; }
+            public static Byte osvrClientShutdown(IntPtr /*OSVR_ClientContext*/ ctx) { return 0; }
+
+            public static Byte osvrClientGetStringParameterLength(SafeClientContextHandle ctx, string path, out UIntPtr len)
+            {
+                len = UIntPtr.Zero;
+                return 0;
+            }
+            
+            public static Byte osvrClientGetStringParameter(SafeClientContextHandle ctx, string path, StringBuilder buf, UIntPtr len) { return 0; }
+            internal static Byte osvrClientCheckStatus(SafeClientContextHandle ctx) { return 0; }
+            internal static Byte osvrClientSetRoomRotationUsingHead(SafeClientContextHandle ctx) { return 0; }
+            internal static Byte osvrClientClearRoomToWorldTransform(SafeClientContextHandle ctx) { return 0; }
+#else
             [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
             public extern static SafeClientContextHandle osvrClientInit([MarshalAs(UnmanagedType.LPStr)] string applicationIdentifier, [MarshalAs(UnmanagedType.U4)] uint flags);
 
@@ -149,6 +174,7 @@ namespace OSVR
 
             [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
             internal extern static Byte osvrClientClearRoomToWorldTransform(SafeClientContextHandle ctx);
+#endif
 
             #endregion ClientKit C functions
 
@@ -409,7 +435,7 @@ namespace OSVR
 
 #endif
 
-            #endregion Support for locating native libraries
+#endregion Support for locating native libraries
 
             /// @brief Initialize the library.
             /// @param applicationIdentifier A string identifying your application.

--- a/ClientKit/ClientKit.cs
+++ b/ClientKit/ClientKit.cs
@@ -16,11 +16,13 @@
 /// limitations under the License.
 /// </copyright>
 
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Win32.SafeHandles;
+#if !WINDOWS_UWP
 using System.Runtime.ConstrainedExecution;
+#endif
 
 #if !MANAGED_OSVR_INTERNAL_PINVOKE
 
@@ -36,11 +38,17 @@ namespace OSVR
         {
             public SafeClientContextHandle() : base(true) { }
 
+#if !WINDOWS_UWP
             [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+#endif
             protected override bool ReleaseHandle()
             {
+#if !WINDOWS_UWP
                 System.Diagnostics.Debug.WriteLine("[OSVR] ClientContext shutdown");
                 return ClientContext.osvrClientShutdown(handle) == OSVR.ClientKit.ClientContext.OSVR_RETURN_SUCCESS;
+#else
+                return true;
+#endif
             }
         }
 
@@ -160,7 +168,7 @@ namespace OSVR
             /// </summary>
             static public void PreloadNativeLibraries(bool loadJointClientKitDlls)
             {
-#if !MANAGED_OSVR_INTERNAL_PINVOKE
+#if !MANAGED_OSVR_INTERNAL_PINVOKE && !WINDOWS_UWP
 
                 // This line based on http://stackoverflow.com/a/864497/265522
                 var assembly = System.Uri.UnescapeDataString((new System.Uri(System.Reflection.Assembly.GetExecutingAssembly().CodeBase)).AbsolutePath);
@@ -193,7 +201,7 @@ namespace OSVR
 #endif
             }
 
-#if !MANAGED_OSVR_INTERNAL_PINVOKE
+#if !MANAGED_OSVR_INTERNAL_PINVOKE && !WINDOWS_UWP
 
             private class LibraryPathAttempter
             {
@@ -504,7 +512,7 @@ namespace OSVR
             public DisplayConfig GetDisplayConfig()
             {
                 SafeDisplayConfigHandle handle;
-                if(DisplayConfigNative.osvrClientGetDisplay(this.m_context, out handle) != OSVR_RETURN_SUCCESS)
+                if (DisplayConfigNative.osvrClientGetDisplay(this.m_context, out handle) != OSVR_RETURN_SUCCESS)
                 {
                     return null;
                 }
@@ -566,7 +574,7 @@ namespace OSVR
                 return buf.ToString();
             }
 
-            
+
             /// <summary>
             /// Updates the internal "room to world" transformation (applied to all
             /// tracker data for this client context instance) based on the user's head
@@ -579,7 +587,7 @@ namespace OSVR
             public void SetRoomRotationUsingHead()
             {
                 Byte success = osvrClientSetRoomRotationUsingHead(m_context);
-                if(OSVR_RETURN_SUCCESS != success)
+                if (OSVR_RETURN_SUCCESS != success)
                 {
                     throw new ApplicationException("OSVR::SetRoomRotationUsingHead() - native osvrClientSetRoomRotationUsingHead call failed.");
                 }
@@ -594,7 +602,7 @@ namespace OSVR
             public void ClearRoomToWorldTransform()
             {
                 Byte success = osvrClientClearRoomToWorldTransform(m_context);
-                if(OSVR_RETURN_SUCCESS != success)
+                if (OSVR_RETURN_SUCCESS != success)
                 {
                     throw new ApplicationException("OSVR::ClearRoomToWorldTransform() - native osvrClientClearRoomToWorldTransform call failed.");
                 }

--- a/ClientKit/ClientKit.win10.csproj
+++ b/ClientKit/ClientKit.win10.csproj
@@ -1,0 +1,156 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{438A507E-5DA4-499F-AD91-DED7B3ADF291}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>OSVR</RootNamespace>
+    <AssemblyName>OSVR.ClientKit</AssemblyName>
+    <DefaultLanguage>en-EN</DefaultLanguage>
+    <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.15063.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.10586.0</TargetPlatformMinVersion>
+    <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
+    <PlatformTarget>ARM</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\ARM\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
+    <PlatformTarget>ARM</PlatformTarget>
+    <OutputPath>bin\ARM\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="AnalogInterface.cs" />
+    <Compile Include="BuildConstants.cs" />
+    <Compile Include="ButtonInterface.cs" />
+    <Compile Include="ClientKit.cs" />
+    <Compile Include="ClientReportTypes.cs" />
+    <Compile Include="DirectionInterface.cs" />
+    <Compile Include="Display.cs" />
+    <Compile Include="EyeTracker2DInterface.cs" />
+    <Compile Include="EyeTracker3DInterface.cs" />
+    <Compile Include="EyeTrackerBlinkInterface.cs" />
+    <Compile Include="ImagingInterface.cs" />
+    <Compile Include="Interface.cs" />
+    <Compile Include="InterfaceAdapter.cs" />
+    <Compile Include="InterfaceBase.cs" />
+    <Compile Include="JointClientKit.cs" />
+    <Compile Include="Location2DInterface.cs" />
+    <Compile Include="MatrixConventions.cs" />
+    <Compile Include="NaviPositionInterface.cs" />
+    <Compile Include="NaviVelocityInterface.cs" />
+    <Compile Include="OrientationInterface.cs" />
+    <Compile Include="Pose3.cs" />
+    <Compile Include="PoseInterface.cs" />
+    <Compile Include="PositionInterface.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Quaternion.cs" />
+    <Compile Include="TimeValue.cs" />
+    <Compile Include="Vec2.cs" />
+    <Compile Include="Vec3.cs" />
+    <Compile Include="Win10Wrapper.cs" />
+    <EmbeddedResource Include="Properties\OSVR.rd.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
+      <Version>5.2.3</Version>
+    </PackageReference>
+  </ItemGroup>
+  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
+    <VisualStudioVersion>14.0</VisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/ClientKit/ClientKit.win10.csproj
+++ b/ClientKit/ClientKit.win10.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OSVR</RootNamespace>
     <AssemblyName>OSVR.ClientKit</AssemblyName>
-    <DefaultLanguage>en-EN</DefaultLanguage>
+    <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.15063.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.10586.0</TargetPlatformMinVersion>
@@ -135,7 +135,9 @@
     <Compile Include="Vec2.cs" />
     <Compile Include="Vec3.cs" />
     <Compile Include="Win10Wrapper.cs" />
-    <EmbeddedResource Include="Properties\OSVR.rd.xml" />
+    <EmbeddedResource Include="Properties\OSVR.rd.xml">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">

--- a/ClientKit/Display.cs
+++ b/ClientKit/Display.cs
@@ -106,6 +106,146 @@ namespace OSVR.ClientKit
             private const string OSVRCoreDll = "osvrClientKit";
 #endif
 
+#if WINDOWS_UWP
+
+        public static Byte osvrClientGetDisplay(SafeClientContextHandle context, out SafeDisplayConfigHandle display)
+        {
+            display = null;
+            return 0;
+        }
+
+        public static Byte osvrClientFreeDisplay(IntPtr display) { return 0; }
+        public static Byte osvrClientCheckDisplayStartup(SafeDisplayConfigHandle context) { return 0; }
+
+        public static Byte osvrClientGetNumDisplayInputs(SafeDisplayConfigHandle display, out DisplayInputCount numDisplayInputs)
+        {
+            numDisplayInputs = new EyeCount();
+            return 0;
+        }
+
+
+        public static Byte osvrClientGetDisplayDimensions(SafeDisplayConfigHandle display, DisplayInputCount displayInputIndex, out DisplayDimension width, out DisplayDimension height)
+        {
+            width = new ViewportDimension();
+            height = new ViewportDimension();
+            return 0;
+        }
+        
+        public static Byte osvrClientGetNumViewers(SafeDisplayConfigHandle display, out ViewerCount viewers)
+        {
+            viewers = new ViewerCount();
+            return 0;
+        }
+        
+        public static Byte osvrClientGetViewerPose(SafeDisplayConfigHandle display,
+            ViewerCount viewer, out Pose3 pose)
+        {
+            pose = new Pose3();
+            return 0;
+        }
+
+        public static Byte osvrClientGetNumEyesForViewer(SafeDisplayConfigHandle display,
+            ViewerCount viewer, out EyeCount eyes)
+        {
+            eyes = new EyeCount();
+            return 0;
+        }
+
+        public static Byte osvrClientGetViewerEyePose(SafeDisplayConfigHandle display,
+            ViewerCount viewer, EyeCount eye, out Pose3 pose)
+        {
+            pose = new Pose3();
+            return 0;
+        }
+
+        public static Byte osvrClientGetViewerEyeViewMatrixd(SafeDisplayConfigHandle display,
+            ViewerCount viewer, EyeCount eye, MatrixConventionsFlags flags, out Matrix44d mat)
+        {
+            mat = new Matrix44d();
+            return 0;
+        }
+
+        public static Byte osvrClientGetViewerEyeViewMatrixf(SafeDisplayConfigHandle display,
+            ViewerCount viewer, EyeCount eye, MatrixConventionsFlags flags, out Matrix44f mat)
+        {
+            mat = new Matrix44f();
+            return 0;
+        }
+
+
+        public static Byte osvrClientGetNumSurfacesForViewerEye(SafeDisplayConfigHandle display,
+            ViewerCount viewer, EyeCount eye, out SurfaceCount surfaces)
+        {
+            surfaces = new ViewerCount();
+            return 0;
+        }
+
+        public static Byte osvrClientGetRelativeViewportForViewerEyeSurface(SafeDisplayConfigHandle display,
+            ViewerCount viewer, EyeCount eye, SurfaceCount surface,
+            out ViewportDimension left, out ViewportDimension bottom, out ViewportDimension width, out ViewportDimension height)
+        {
+            left = new ViewportDimension();
+            bottom = new ViewportDimension();
+            width = new ViewportDimension();
+            height = new ViewportDimension();
+            return 0;
+        }
+
+        public static Byte osvrClientGetViewerEyeSurfaceDisplayInputIndex(SafeDisplayConfigHandle display,
+            ViewerCount viewer, EyeCount eye, SurfaceCount surface, out DisplayInputCount displayInput)
+        {
+            displayInput = new EyeCount();
+            return 0;
+        }
+
+        public static Byte osvrClientGetViewerEyeSurfaceProjectionMatrixd(SafeDisplayConfigHandle display,
+            ViewerCount viewer, EyeCount eye, SurfaceCount surface, double near, double far,
+            MatrixConventionsFlags flags, out Matrix44d matrix)
+        {
+            matrix = new Matrix44d();
+            return 0;
+        }
+
+        public static Byte osvrClientGetViewerEyeSurfaceProjectionMatrixf(SafeDisplayConfigHandle display,
+            ViewerCount viewer, EyeCount eye, SurfaceCount surface, float near, float far,
+            MatrixConventionsFlags flags, out Matrix44f matrix)
+        {
+            matrix = new Matrix44f();
+            return 0;
+        }
+
+        public static Byte osvrClientGetViewerEyeSurfaceProjectionClippingPlanes(SafeDisplayConfigHandle display,
+            ViewerCount viewer, EyeCount eye, SurfaceCount surface,
+            out double left, out double right, out double bottom, out double top)
+        {
+            left = 0;
+            right = 0;
+            bottom = 0;
+            top = 0;
+            return 0;
+        }
+
+        public static Byte osvrClientDoesViewerEyeSurfaceWantDistortion(SafeDisplayConfigHandle display,
+            ViewerCount viewer, EyeCount eye, SurfaceCount surface, [MarshalAs(UnmanagedType.I1)]out bool distortionRequested)
+        {
+            distortionRequested = false;
+            return 0;
+        }
+        
+        public static Byte osvrClientGetViewerEyeSurfaceRadialDistortionPriority(SafeDisplayConfigHandle display,
+            ViewerCount viewer, EyeCount eye, SurfaceCount surface, out DistortionPriority priority)
+        {
+            priority = 0;
+            return 0;
+        }
+
+        public static Byte osvrClientGetViewerEyeSurfaceRadialDistortion(SafeDisplayConfigHandle display,
+            ViewerCount viewer, EyeCount eye, SurfaceCount surface, out RadialDistortionParameters distortionParams)
+        {
+            distortionParams = new RadialDistortionParameters();
+            return 0;
+        }
+#else
         [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientGetDisplay(SafeClientContextHandle context, out SafeDisplayConfigHandle display);
 
@@ -184,6 +324,7 @@ namespace OSVR.ClientKit
         [DllImport(OSVRCoreDll, CallingConvention = CallingConvention.Cdecl)]
         public extern static Byte osvrClientGetViewerEyeSurfaceRadialDistortion(SafeDisplayConfigHandle display,
             ViewerCount viewer, EyeCount eye, SurfaceCount surface, out RadialDistortionParameters distortionParams);
+#endif
     }
 
     public struct Viewport

--- a/ClientKit/Display.cs
+++ b/ClientKit/Display.cs
@@ -20,7 +20,9 @@
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Win32.SafeHandles;
+#if !WINDOWS_UWP
 using System.Runtime.ConstrainedExecution;
+#endif
 
 using ViewportDimension = System.Int32;
 using ViewerCount = System.UInt32;
@@ -36,10 +38,16 @@ namespace OSVR.ClientKit
     {
         public SafeDisplayConfigHandle() : base(true) { }
 
+#if !WINDOWS_UWP
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+#endif
         protected override bool ReleaseHandle()
         {
+#if !WINDOWS_UWP
             return DisplayConfigNative.osvrClientFreeDisplay(handle) == OSVR.ClientKit.ClientContext.OSVR_RETURN_SUCCESS;
+#else
+            return true;
+#endif
         }
     }
 

--- a/ClientKit/ImagingInterface.cs
+++ b/ClientKit/ImagingInterface.cs
@@ -42,8 +42,12 @@ namespace OSVR.ClientKit
         const string OSVR_CORE_DLL = "osvrClientKit";
 #endif
 
+#if WINDOWS_UWP
+        public static Byte osvrClientFreeImage(SafeClientContextHandle ctx, IntPtr imageData) { return 0; }
+#else
         [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
         public static extern Byte osvrClientFreeImage(SafeClientContextHandle ctx, IntPtr imageData);
+#endif
     }
 
     /// <summary>

--- a/ClientKit/Interface.cs
+++ b/ClientKit/Interface.cs
@@ -17,7 +17,9 @@
 /// </copyright>
 using Microsoft.Win32.SafeHandles;
 using System;
+#if !WINDOWS_UWP
 using System.Runtime.ConstrainedExecution;
+#endif
 using System.Runtime.InteropServices;
 
 namespace OSVR
@@ -29,11 +31,17 @@ namespace OSVR
         {
             public SafeClientInterfaceHandle() : base(true) { }
 
+#if !WINDOWS_UWP
             [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+#endif
             override protected bool ReleaseHandle()
             {
+#if !WINDOWS_UWP
                 System.Diagnostics.Debug.WriteLine("[OSVR] Interface shutdown");
                 return Interface.osvrClientFreeInterface(handle) == OSVR.ClientKit.ClientContext.OSVR_RETURN_SUCCESS;
+#else
+                return true;
+#endif
             }
         }
 

--- a/ClientKit/Interface.cs
+++ b/ClientKit/Interface.cs
@@ -103,7 +103,35 @@ namespace OSVR
             //typedef struct OSVR_ClientInterfaceObject *OSVR_ClientInterface;
             //typedef char OSVR_ReturnCode; (0 == OSVR_RETURN_SUCCESS; 1 == OSVR_RETURN_FAILURE)
 
-
+#if WINDOWS_UWP
+            public static Byte osvrRegisterPositionCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] PositionCallback cb, IntPtr /*void**/ userdata) { return 0; }
+            public static Byte osvrRegisterPoseCallback(SafeClientInterfaceHandle iface, PoseCallback cb, IntPtr /*void**/ userdata) { return 0; }
+            public static Byte osvrRegisterOrientationCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] OrientationCallback cb, IntPtr /*void**/ userdata) { return 0; }
+            public static Byte osvrRegisterButtonCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] ButtonCallback cb, IntPtr /*void**/ userdata) { return 0; }
+            public static Byte osvrRegisterAnalogCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] AnalogCallback cb, IntPtr /*void**/ userdata) { return 0; }
+            public static Byte osvrRegisterLocation2DCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] Location2DCallback cb, IntPtr /*void**/ userdata) { return 0; }
+            public static Byte osvrRegisterDirectionCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] DirectionCallback cb, IntPtr /*void**/ userdata) { return 0; }
+            public static Byte osvrRegisterEyeTracker2DCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] EyeTracker2DCallback cb, IntPtr /*void**/ userdata) { return 0; }
+            public static Byte osvrRegisterEyeTracker3DCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] EyeTracker3DCallback cb, IntPtr /*void**/ userdata) { return 0; }
+            public static Byte osvrRegisterEyeTrackerBlinkCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] EyeTrackerBlinkCallback cb, IntPtr /*void**/ userdata) { return 0; }
+            public static Byte osvrRegisterImagingCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] ImagingCallback cb, IntPtr /*void**/ userdata) { return 0; }
+            public static Byte osvrRegisterNaviVelocityCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] NaviVelocityCallback cb, IntPtr /*void*/ userdata) { return 0; }
+            public static Byte osvrRegisterNaviPositionCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] NaviPositionCallback cb, IntPtr /*void*/ userdata) { return 0; }
+            public static Byte osvrClientGetInterface(SafeClientContextHandle ctx, string path, ref SafeClientInterfaceHandle iface) { return 0; }
+            public static Byte osvrGetPoseState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref Pose3 state) { return 0; }
+            public static Byte osvrGetPositionState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref Vec3 state) { return 0; }
+            public static Byte osvrGetOrientationState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref Quaternion state) { return 0; }
+            public static Byte osvrGetButtonState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref Byte state) { return 0; }
+            public static Byte osvrGetAnalogState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref Double state) { return 0; }
+            public static Byte osvrGetLocation2DState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref Vec2 state) { return 0; }
+            public static Byte osvrGetDirectionState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref Vec3 state) { return 0; }
+            public static Byte osvrGetEyeTracker2DState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref Vec2 state) { return 0; }
+            public static Byte osvrGetEyeTracker3DState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref EyeTracker3DState state) { return 0; }
+            public static Byte osvrGetEyeTrackerBlinkState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, [MarshalAs(UnmanagedType.I1)]ref bool state) { return 0; }
+            public static Byte osvrGetNaviVelocityState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref Vec2 state) { return 0; }
+            public static Byte osvrGetNaviPositionState(SafeClientInterfaceHandle iface, ref TimeValue timestamp, ref Vec2 state) { return 0; }
+            public static Byte osvrClientFreeInterface(IntPtr iface) { return 0; }
+#else
             [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrRegisterPositionCallback(SafeClientInterfaceHandle iface, [MarshalAs(UnmanagedType.FunctionPtr)] PositionCallback cb, IntPtr /*void**/ userdata);
 
@@ -184,6 +212,7 @@ namespace OSVR
 
             [DllImport(OSVR_CORE_DLL, CallingConvention = CallingConvention.Cdecl)]
             public extern static Byte osvrClientFreeInterface(IntPtr iface);
+#endif
 
             #endregion
 

--- a/ClientKit/JointClientKit.cs
+++ b/ClientKit/JointClientKit.cs
@@ -50,6 +50,17 @@ namespace OSVR.ClientKit
         private const string JointClientKitDll = "osvrJointClientKit";
 #endif
 
+#if WINDOWS_UWP
+        public static IntPtr osvrJointClientCreateOptions() { return IntPtr.Zero; }
+        public static Byte osvrJointClientOptionsAutoloadPlugins(IntPtr options) { return 0; }
+        public static Byte osvrJointClientOptionsLoadPlugin(IntPtr options, string pluginName) { return 0; }
+        public static Byte osvrJointClientOptionsInstantiateDriver(IntPtr options, string pluginName, string driverName, string parameters) { return 0; }
+        public static Byte osvrJointClientOptionsAddAlias(IntPtr options, string path, string source) { return 0; }
+        public static Byte osvrJointClientOptionsAddAliases(IntPtr options, string aliases) { return 0; }
+        public static Byte osvrJointClientOptionsAddString(IntPtr options, string path, string s) { return 0; }
+        public static Byte osvrJointClientOptionsTriggerHardwareDetect(IntPtr options) { return 0; }
+        public static SafeClientContextHandle osvrJointClientInit(string applicationIdentifier, IntPtr options) { return null; }
+#else
         [DllImport(JointClientKitDll, CallingConvention = CallingConvention.Cdecl)]
         public extern static IntPtr /*SafeJointClientOptionsHandle*/ osvrJointClientCreateOptions();
 
@@ -82,6 +93,7 @@ namespace OSVR.ClientKit
         [DllImport(JointClientKitDll, CallingConvention = CallingConvention.Cdecl)]
         public extern static SafeClientContextHandle osvrJointClientInit(
             string applicationIdentifier, IntPtr /*SafeJointClientOptionsHandle*/ options);
+#endif
     }
 
     /// <summary>

--- a/ClientKit/JointClientKit.cs
+++ b/ClientKit/JointClientKit.cs
@@ -18,7 +18,9 @@
 /// </copyright>
 using System;
 using System.Collections.Generic;
+#if !WINDOWS_UWP
 using System.Runtime.ConstrainedExecution;
+#endif
 using System.Runtime.InteropServices;
 using System.Text;
 

--- a/ClientKit/MatrixConventions.cs
+++ b/ClientKit/MatrixConventions.cs
@@ -154,11 +154,26 @@ namespace OSVR.ClientKit
         private const string OSVRUtilDll = "osvrUtil";
 #endif
 
+
+#if WINDOWS_UWP
+        public static Byte osvrPose3ToMatrixd(ref Pose3 pose, MatrixConventionsFlags flags, out Matrix44d mat)
+        {
+            mat = new Matrix44d();
+            return 0;
+        }
+
+        public static Byte osvrPose3ToMatrixf(ref Pose3 pose, MatrixConventionsFlags flags, out Matrix44f mat)
+        {
+            mat = new Matrix44f();
+            return 0;
+        }
+#else
         [DllImport(OSVRUtilDll, CallingConvention = CallingConvention.Cdecl)]
         public static extern Byte osvrPose3ToMatrixd(ref Pose3 pose, MatrixConventionsFlags flags, out Matrix44d mat);
 
         [DllImport(OSVRUtilDll, CallingConvention = CallingConvention.Cdecl)]
         public static extern Byte osvrPose3ToMatrixf(ref Pose3 pose, MatrixConventionsFlags flags, out Matrix44f mat);
+#endif
     }
 
     public static class MatrixConventions

--- a/ClientKit/Properties/AssemblyInfo.cs
+++ b/ClientKit/Properties/AssemblyInfo.cs
@@ -19,6 +19,9 @@
 
 using OSVR.ClientKit;
 using System.Reflection;
+#if WINDOWS_UWP
+using System.Runtime.InteropServices;
+#endif
 
 [assembly: AssemblyTitle("OSVR ClientKit (" + BuildConstants.FrameworkDescription + ")")]
 [assembly: AssemblyDescription(BuildConstants.FrameworkDescription + "/" + BuildConstants.Configuration + BuildConstants.InternalPInvokeString)]
@@ -29,14 +32,13 @@ using System.Reflection;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
+[assembly: AssemblyVersion("0.1.*")]
+
 // The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion("0.1.*")]
-
-// The following attributes are used to specify the signing key for the assembly,
-// if desired. See the Mono documentation for more information about signing.
-
-//[assembly: AssemblyDelaySign(false)]
-//[assembly: AssemblyKeyFile("")]
+#if WINDOWS_UWP
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: ComVisible(false)]
+#endif

--- a/ClientKit/Properties/OSVR.rd.xml
+++ b/ClientKit/Properties/OSVR.rd.xml
@@ -25,7 +25,7 @@
     https://go.microsoft.com/fwlink/?LinkID=391919
 -->
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
-  <Library Name="OSVR">
+  <Library Name="OSVR.ClientKit">
 
   	<!-- ajoutez ici les directives pour votre bibliothèque -->
 

--- a/ClientKit/Properties/OSVR.rd.xml
+++ b/ClientKit/Properties/OSVR.rd.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Ce fichier contient des directives runtime, des spécifications relatives aux types auxquels votre application a accès
+    via la réflexion et d'autres modèles de code dynamique. Les directives runtime permettent de contrôler
+    l'optimiseur .NET Native et de vérifier qu'il ne supprime pas le code accessible à votre bibliothèque. Si votre
+    bibliothèque ne fait pas de réflexion, vous n'avez pas à modifier ce fichier en principe. Cependant,
+    si votre bibliothèque effectue une réflexion des types, en particulier les types qui lui sont passés ou qui dérivent de ses types,
+    vous devez écrire des directives runtime.
+
+    En règle générale, l'usage de la réflexion dans les bibliothèques permet de découvrir les informations relatives aux types passés
+    à la bibliothèque. Les directives runtime ont trois façons d'exprimer les exigences des types passés à
+    votre bibliothèque.
+
+    1.  Parameter, GenericParameter, TypeParameter, TypeEnumerableParameter
+        Utilisez ces directives pour refléter les types passés en tant que paramètres.
+
+    2.  SubTypes
+        Utilisez une directive SubTypes pour refléter les types dérivés d'un autre type.
+
+    3.  AttributeImplies
+        Utilisez une directive AttributeImplies pour indiquer que votre bibliothèque doit refléter
+        les types ou les méthodes décorés avec un attribut.
+
+    Pour plus d'informations sur l'écriture de directives runtime pour les bibliothèques, visitez
+    https://go.microsoft.com/fwlink/?LinkID=391919
+-->
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library Name="OSVR">
+
+  	<!-- ajoutez ici les directives pour votre bibliothèque -->
+
+  </Library>
+</Directives>

--- a/ClientKit/Win10Wrapper.cs
+++ b/ClientKit/Win10Wrapper.cs
@@ -1,0 +1,24 @@
+﻿#if WINDOWS_UWP
+using System;
+
+namespace OSVR.ClientKit
+{
+    public class SafeHandleZeroOrMinusOneIsInvalid : IDisposable
+    {
+        public bool IsClosed;
+        public bool IsInvalid;
+
+        public SafeHandleZeroOrMinusOneIsInvalid(bool value) { }
+
+        public void Close() { }
+        public void Dispose() { }
+        protected virtual bool ReleaseHandle() { return true; }
+    }
+
+    public class ApplicationException : Exception
+    {
+        public ApplicationException(string message)
+            : base(message) { }
+    }
+}
+#endif

--- a/Managed-OSVR.win10.sln
+++ b/Managed-OSVR.win10.sln
@@ -1,0 +1,40 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.6
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClientKit", "ClientKit/ClientKit.win10.csproj", "{438A507E-5DA4-499F-AD91-DED7B3ADF291}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|ARM = Debug|ARM
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|ARM = Release|ARM
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{438A507E-5DA4-499F-AD91-DED7B3ADF291}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{438A507E-5DA4-499F-AD91-DED7B3ADF291}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{438A507E-5DA4-499F-AD91-DED7B3ADF291}.Debug|ARM.ActiveCfg = Debug|ARM
+		{438A507E-5DA4-499F-AD91-DED7B3ADF291}.Debug|ARM.Build.0 = Debug|ARM
+		{438A507E-5DA4-499F-AD91-DED7B3ADF291}.Debug|x64.ActiveCfg = Debug|x64
+		{438A507E-5DA4-499F-AD91-DED7B3ADF291}.Debug|x64.Build.0 = Debug|x64
+		{438A507E-5DA4-499F-AD91-DED7B3ADF291}.Debug|x86.ActiveCfg = Debug|x86
+		{438A507E-5DA4-499F-AD91-DED7B3ADF291}.Debug|x86.Build.0 = Debug|x86
+		{438A507E-5DA4-499F-AD91-DED7B3ADF291}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{438A507E-5DA4-499F-AD91-DED7B3ADF291}.Release|Any CPU.Build.0 = Release|Any CPU
+		{438A507E-5DA4-499F-AD91-DED7B3ADF291}.Release|ARM.ActiveCfg = Release|ARM
+		{438A507E-5DA4-499F-AD91-DED7B3ADF291}.Release|ARM.Build.0 = Release|ARM
+		{438A507E-5DA4-499F-AD91-DED7B3ADF291}.Release|x64.ActiveCfg = Release|x64
+		{438A507E-5DA4-499F-AD91-DED7B3ADF291}.Release|x64.Build.0 = Release|x64
+		{438A507E-5DA4-499F-AD91-DED7B3ADF291}.Release|x86.ActiveCfg = Release|x86
+		{438A507E-5DA4-499F-AD91-DED7B3ADF291}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Hi,

This PR fixes the native C# dll to be able to be built with Visual Studio on a Windows 10 Universal Project.
With Unity, we can build games for all plateforms, including Windows Store. The Windows Store C# API is limited because apps are sandboxed. So the current OSVR.ClientKit dll can't be used with Unity (Win32 calls).

We know that OSVR doesn't support Windows Store, but without those changes, it's impossible for a developer to deploy a project to this platform. The result is two DLLs, the one who already know and another who is just used by a Windows 10 project.

For the Unity SDK, I recommand you to create a new folder called `windows10` in the `Plugins` folder and copy the new dll into it. Set its build target to Windows Store only (not editor, runtime, just Windows Store).  The build target of the current dll have to be changed to exclude Windows Store.

![image](https://cloud.githubusercontent.com/assets/1017126/26033269/09303148-38a9-11e7-9524-611b06f0be7e.png)
- This is the Win10 setup

![image](https://cloud.githubusercontent.com/assets/1017126/26033271/0cd73c10-38a9-11e7-85d6-70700e94b40a.png)
- And the current DLL setup